### PR TITLE
Improve desktop layout and fix lint issues

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -13,7 +13,7 @@
     --text-color: #333;
     --text-light: #666;
     --background-color: #f9f9f9;
-    --card-background: #ffffff;
+    --card-background: #fff;
     --border-color: #ddd;
     --border-radius: 15px;
     --box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
@@ -55,7 +55,7 @@ body {
 .dark-mode-toggle {
     position: fixed;
     top: 20px;
-    right: 20px;
+    right: 30px;
     z-index: 1000;
     background: var(--card-background);
     border: 2px solid var(--border-color);
@@ -284,15 +284,15 @@ body {
 /* Features and Icons */
 .feature-icon {
     font-size: 36px;
-    margin-bottom: 20px;
+    margin-bottom: 30px;
     color: var(--primary-color);
 }
 
 /* Progress Tracker */
-#progressTracker {
+#progress-tracker {
     position: fixed;
-    bottom: 20px;
-    right: 20px;
+    bottom: 30px;
+    right: 30px;
     z-index: 1000;
     background-color: var(--card-background);
     border: 2px solid var(--border-color);
@@ -304,14 +304,18 @@ body {
     color: var(--text-color);
 }
 
-#progressTracker:hover {
+#progress-tracker:hover {
     box-shadow: var(--hover-shadow);
     transform: translateY(-2px);
 }
 
-#progressTracker h6 {
+#progress-tracker h6 {
     color: var(--text-color);
     margin-bottom: 15px;
+}
+
+.modal-open #progress-tracker {
+    display: none;
 }
 
 .progress {
@@ -328,7 +332,7 @@ body {
     transition: width 0.6s ease;
 }
 
-#progressStatus {
+#progress-status {
     color: var(--text-light);
     font-size: 0.9em;
 }
@@ -368,13 +372,13 @@ body {
 }
 
 /* Quiz Tab Navigation - Specific styling for quiz tabs */
-#quizNav {
+#quiz-nav {
     border-bottom: 2px solid var(--border-color);
     padding-bottom: 1rem;
     margin-bottom: 2rem;
 }
 
-#quizNav .nav-link {
+#quiz-nav .nav-link {
     color: var(--text-color);
     background-color: var(--card-background);
     border: 2px solid var(--border-color);
@@ -386,7 +390,7 @@ body {
     margin-bottom: 8px;
 }
 
-#quizNav .nav-link.active {
+#quiz-nav .nav-link.active {
     background-color: var(--primary-color);
     color: white;
     border-color: var(--primary-color);
@@ -394,7 +398,7 @@ body {
     transform: translateY(-2px);
 }
 
-#quizNav .nav-link:hover:not(.active) {
+#quiz-nav .nav-link:hover:not(.active) {
     background-color: var(--primary-light);
     border-color: var(--primary-color);
     transform: translateY(-1px);
@@ -402,7 +406,7 @@ body {
 }
 
 /* Dark mode quiz navigation */
-.dark-mode #quizNav .nav-link:hover:not(.active) {
+.dark-mode #quiz-nav .nav-link:hover:not(.active) {
     background-color: #2c3e50;
     color: var(--text-color);
 }
@@ -744,7 +748,7 @@ body {
 
 /* Media Queries */
 @media (max-width: 991.98px) {
-    #progressTracker {
+    #progress-tracker {
         position: static;
         margin: 30px auto;
         display: block;
@@ -775,11 +779,11 @@ body {
         text-align: center;
     }
     
-    #quizNav {
+    #quiz-nav {
         flex-direction: column;
     }
     
-    #quizNav .nav-link {
+    #quiz-nav .nav-link {
         margin-bottom: 10px;
         margin-right: 0;
         text-align: center;
@@ -787,7 +791,7 @@ body {
     }
     
     .card {
-        margin-bottom: 20px;
+        margin-bottom: 30px;
     }
     
     .dark-mode-toggle {

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
     
     <!-- Header -->
     <header class="hero-section">
-        <div class="container">
+        <div class="container-fluid">
             <div class="row align-items-center">
                 <div class="col-lg-6">
                     <h1 class="fw-bold mb-3">Ad Tech Learning Platform</h1>
@@ -143,12 +143,12 @@
     </main>
 
     <!-- Progress Tracker -->
-    <aside id="progressTracker" aria-live="polite" aria-label="Learning progress tracker">
+    <aside id="progress-tracker" aria-live="polite" aria-label="Learning progress tracker">
         <h6 class="mb-2">Your Learning Progress</h6>
         <div class="progress mb-3" role="progressbar" aria-label="Learning progress" aria-valuemin="0" aria-valuemax="100">
             <div class="progress-bar progress-bar-animated" style="width: 0%;" aria-valuenow="0">0%</div>
         </div>
-        <div class="small text-muted" id="progressStatus">Just started</div>
+        <div class="small text-muted" id="progress-status">Just started</div>
     </aside>
 
     <!-- Modals -->
@@ -157,7 +157,7 @@
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="aboutModalLabel">About Ad Tech & This Learning Platform</h5>
+                    <h5 class="modal-title" id="aboutModalLabel">About Ad Tech &amp; This Learning Platform</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -169,8 +169,8 @@
                     <ul>
                         <li>Programmatic Media Buying</li>
                         <li>Ad Operations</li>
-                        <li>Data Analysis & Optimization</li>
-                        <li>Ad Tech Sales & Business Development</li>
+                        <li>Data Analysis &amp; Optimization</li>
+                        <li>Ad Tech Sales &amp; Business Development</li>
                         <li>Product Management in Ad Tech Companies</li>
                         <li>Marketing Technology Integration</li>
                     </ul>
@@ -206,14 +206,14 @@
                             flowchart TD
                                 A[Start Here] --> B[Ad Tech Fundamentals]
                                 B --> C[Key Players in Ad Tech]
-                                C --> D[Ad Formats & Metrics]
+                                C --> D[Ad Formats &amp; Metrics]
                                 D --> E[Programmatic Advertising]
                                 E --> F[Real-Time Bidding]
                                 F --> G[Targeting Methods]
                                 G --> H[Data Management]
                                 H --> I[Header Bidding]
-                                I --> J[Attribution & Measurement]
-                                J --> K[Privacy & Identity]
+                                I --> J[Attribution &amp; Measurement]
+                                J --> K[Privacy &amp; Identity]
                                 K --> L[Emerging Trends]
                                 
                                 style B fill:#d4f1f9
@@ -239,9 +239,9 @@
                                     <p class="card-text">Estimated time: 1-2 hours</p>
                                     <ul class="small">
                                         <li>Ad Tech Fundamentals</li>
-                                        <li>Key Players & Ecosystem</li>
+                                        <li>Key Players &amp; Ecosystem</li>
                                         <li>Common Ad Formats</li>
-                                        <li>Basic Metrics & KPIs</li>
+                                        <li>Basic Metrics &amp; KPIs</li>
                                     </ul>
                                 </div>
                             </div>
@@ -270,7 +270,7 @@
                                     <ul class="small">
                                         <li>Header Bidding</li>
                                         <li>Attribution Models</li>
-                                        <li>Privacy & Identity</li>
+                                        <li>Privacy &amp; Identity</li>
                                         <li>Emerging Trends</li>
                                     </ul>
                                 </div>

--- a/js/app.js
+++ b/js/app.js
@@ -417,7 +417,7 @@ function loadQuizSection() {
         <h2 class="section-title">Test Your Ad Tech Knowledge</h2>
         <p class="lead mb-5">Challenge yourself with these quizzes to reinforce your understanding of Ad Tech concepts.</p>
 
-        <ul class="nav nav-pills mb-4 justify-content-center" id="quizNav" role="tablist">
+        <ul class="nav nav-pills mb-4 justify-content-center" id="quiz-nav" role="tablist">
             <li class="nav-item" role="presentation">
                 <button class="nav-link active" id="beginner-quiz-tab" data-quiz-target="beginnerQuiz" type="button" role="tab">
                     <i class="fas fa-seedling me-2"></i>Beginner
@@ -639,8 +639,8 @@ function setupEventListeners() {
  * Set up navigation event listeners
  */
 function setupNavigationListeners() {
-    const progressBar = document.querySelector('#progressTracker .progress-bar');
-    const progressStatus = document.getElementById('progressStatus');
+    const progressBar = document.querySelector('#progress-tracker .progress-bar');
+    const progressStatus = document.getElementById('progress-status');
     
     // Start learning buttons
     ['startLearningBtn', 'startLearningModalBtn', 'beginnerBtn'].forEach(btnId => {
@@ -859,7 +859,7 @@ function loadQuizContent(quizId, quizData) {
 }
 
 function setupQuizTabNavigation() {
-    const quizNavTabs = document.querySelectorAll('#quizNav .nav-link');
+    const quizNavTabs = document.querySelectorAll('#quiz-nav .nav-link');
     
     quizNavTabs.forEach(tab => {
         tab.addEventListener('click', function(e) {
@@ -971,11 +971,11 @@ function handleQuizSubmission(section) {
     } else if (correctCount === questions.length) {
         resultDiv.className += ' alert-success';
         resultDiv.innerHTML = `<i class="fas fa-trophy me-2"></i> Perfect! You got all ${questions.length} questions correct!`;
-        updateProgress(10, document.querySelector('#progressTracker .progress-bar'), document.getElementById('progressStatus'));
+        updateProgress(10, document.querySelector('#progress-tracker .progress-bar'), document.getElementById('progress-status'));
     } else {
         resultDiv.className += ' alert-info';
         resultDiv.innerHTML = `<i class="fas fa-check-circle me-2"></i> You got ${correctCount} out of ${questions.length} questions correct.`;
-        updateProgress(5, document.querySelector('#progressTracker .progress-bar'), document.getElementById('progressStatus'));
+        updateProgress(5, document.querySelector('#progress-tracker .progress-bar'), document.getElementById('progress-status'));
     }
     
     quizContainer.appendChild(resultDiv);

--- a/tests/updateProgress.test.js
+++ b/tests/updateProgress.test.js
@@ -20,7 +20,7 @@ describe('updateProgress', () => {
     progressBar.textContent = '0%';
 
     progressStatus = document.createElement('div');
-    progressStatus.id = 'progressStatus';
+    progressStatus.id = 'progress-status';
     progressStatus.textContent = 'Just started';
 
     document.body.appendChild(progressBar);


### PR DESCRIPTION
## Summary
- make hero banner full width with `container-fluid`
- hide progress tracker when modals open and adjust offsets
- rename camelCase IDs to kebab-case
- escape ampersands in roadmap modal
- update tests for renamed IDs

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843eca8632c832caf925e8ee6f8cddb